### PR TITLE
fixed EXTRA_ARGS for kaniko

### DIFF
--- a/base/instavote-ci-pipeline.yaml
+++ b/base/instavote-ci-pipeline.yaml
@@ -119,7 +119,7 @@ spec:
     - name: IMAGE
       value: '$(params.imageUrl):$(params.revision)-$(tasks.misc.results.short-sha)-$(tasks.misc.results.current-ts)'
     - name: EXTRA_ARGS
-      value: "--skip-tls-verify"
+      value: ["--skip-tls-verify"]
   - name: verify-digest
     runAfter:
     - img-build-publish


### PR DESCRIPTION
The pipelinerun currently fails with the following logs:
```
invalid input params for task kaniko: param types don't match the user-specified type: [EXTRA_ARGS]
```
This seems to be due to the fact that `EXTRA_ARGS` needs to be an array (cf https://github.com/tektoncd/catalog/blob/main/task/kaniko/0.5/kaniko.yaml#L32 )